### PR TITLE
Add section for unreliable sources / failed verification; explain LEDECITE

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -178,7 +178,11 @@
                 <p>
                     It's really simple: find a statement of fact in an article and click the little
                     blue number next to it — you'll be taken to the bottom of the page and the
-                    relevant citation will be highlighted.
+                    relevant citation will be highlighted. (If the statement is in the article's
+                    <span title="lede"
+                          >lead</span
+                    > section or in the "infobox" on the right side, it often won't have an inline citation;
+                    instead, check the appropriate part of the article.)
                 </p>
                 <p>
                     <img loading="lazy" src="img/howto.gif" class="gif" />
@@ -212,15 +216,15 @@
                     The next time someone sends you a Wikipedia article to prove their point,
                     instead of proudly declaring "HAH! Don't you know <i>anyone</i> can edit
                     Wikipedia?!", find the statement in the article they are referring to and read
-                    the reliable source instead.
+                    the cited source instead.
                 </p>
                 <p>
-                    If the statement your opponent is referencing doesn't have an
+                    If the statement your opponent is referencing <i>doesn't</i> have an
                     <a href="https://en.wikipedia.org/wiki/Wikipedia:Citing_sources" target="_blank"
                         >inline citation</a
                     >
-                    (or if the citation actually says something <i>else</i>), then by all means call
-                    them out.
+                    to a reliable source (or if the citation actually says something <i>else</i>),
+                    then by all means call them out—and, if you want, come fix the error!
                 </p>
             </section>
 

--- a/public/index.html
+++ b/public/index.html
@@ -179,31 +179,31 @@
                     It's really simple: find a statement of fact in an article and click the little
                     blue number next to it — you'll be taken to the bottom of the page and the
                     relevant citation will be highlighted. (If the statement is in the article's
-                    <span title="lede"
-                          >lead</span
-                    > section or in the "infobox" on the right side, it often won't have an inline citation;
-                    instead, check the appropriate part of the article.)
+                    <span title="lede">lead</span> section or in the "infobox" on the right side, it
+                    often won't have an inline citation; instead, check the appropriate part of the
+                    article.)
                 </p>
                 <p>
                     <img loading="lazy" src="img/howto.gif" class="gif" />
                 </p>
                 <h3>What if the cited source is unreliable or doesn't support the claim?</h3>
                 <p>
-                    Well first of all, you can now enjoy the smug satisfaction of telling your friend
-                    not just that Wikipedia is unreliable, but that <i>Wikipedia's source</i> is
-                    unreliable. Then, if you'd like to help, you can fix the article. Make sure to use
-                    a descriptive
-                    <a href="https://en.wikipedia.org/wiki/Help:Edit_summary"
-                       target="_blank"
-                       >edit summary</a
-                    >, so that your change isn't mistaken for vandalism.  Say something like "Random YouTube
-                    videos like https://www.youtube.com/watch?v=dQw4w9WgXcQ aren't reliable sources" or
-                    "Page 57 of Steven Chu's autobiography doesn't mention the scroll lock key at all".
-                    If you are unable to edit the page because it is
-                    <a href="https://en.wikipedia.org/wiki/Wikipedia:Protection_policy#Semi-protection"
-                       target="_blank"
-                       >semi-protected</a
-                    >, there will be instructions in the editing window on how to request an edit instead.
+                    Well first of all, you can now enjoy the smug satisfaction of telling your
+                    friend not just that Wikipedia is unreliable, but that
+                    <i>Wikipedia's source</i> is unreliable. Then, if you'd like to help, you can
+                    fix the article. Make sure to use a descriptive
+                    <a href="https://en.wikipedia.org/wiki/Help:Edit_summary" target="_blank"
+                        >edit summary</a
+                    >, so that your change isn't mistaken for vandalism. Say something like "Random
+                    YouTube videos like https://www.youtube.com/watch?v=dQw4w9WgXcQ aren't reliable
+                    sources" or "Page 57 of Steven Chu's autobiography doesn't mention the scroll
+                    lock key at all". If you are unable to edit the page because it is
+                    <a
+                        href="https://en.wikipedia.org/wiki/Wikipedia:Protection_policy#Semi-protection"
+                        target="_blank"
+                        >semi-protected</a
+                    >, there will be instructions in the editing window on how to request an edit
+                    instead.
                 </p>
             </section>
 

--- a/public/index.html
+++ b/public/index.html
@@ -183,6 +183,23 @@
                 <p>
                     <img loading="lazy" src="img/howto.gif" class="gif" />
                 </p>
+                <h3>What if the cited source is unreliable or doesn't support the claim?</h3>
+                <p>
+                    Well first of all, you can now enjoy the smug satisfaction of telling your friend
+                    not just that Wikipedia is unreliable, but that <i>Wikipedia's source</i> is
+                    unreliable. Then, if you'd like to help, you can fix the article. Make sure to use
+                    a descriptive
+                    <a href="https://en.wikipedia.org/wiki/Help:Edit_summary"
+                       target="_blank"
+                       >edit summary</a
+                    >, so that your change isn't mistaken for vandalism.  Say something like "Random YouTube
+                    videos like https://www.youtube.com/watch?v=dQw4w9WgXcQ aren't reliable sources" or
+                    "Page 57 of Steven Chu's autobiography doesn't mention the scroll lock key at all".
+                    If you are unable to edit the page because it is
+                    <a href="https://en.wikipedia.org/wiki/Wikipedia:Protection_policy#Semi-protection"
+                       target="_blank"
+                       >semi-protected</a
+                    >, there will be instructions in the editing window on how to request an edit instead.
             </section>
 
             <section id="tldr">

--- a/public/index.html
+++ b/public/index.html
@@ -200,6 +200,7 @@
                        target="_blank"
                        >semi-protected</a
                     >, there will be instructions in the editing window on how to request an edit instead.
+                </p>
             </section>
 
             <section id="tldr">


### PR DESCRIPTION
The added section is an obvious follow-up question from the reader: "What if the cited source is unreliable or doesn't support the claim?" Here we have a chance to persuade readers to become editors, if we give them clear instructions on how to fix errors they encounter. This strengthens the image that Wikipedia is imperfect, but always looking to improve.

The LEDECITE explanation is to avoid a situation where this essay tells people to look for citations, but no citations are found in the place that they're looking, despite that information being present elsewhere in the article.